### PR TITLE
Add full-screen toggle on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ https://alphakevin.github.io/screen-color-tester/
 
 - Use <kbd>↑</kbd> or <kbd>←</kbd> to change color forward
 - Use <kbd>↓</kbd> or <kbd>→</kbd> to change color backward
-- Use <kbd>F11</kbd> or click on the page to toggle full-screen mode
-- Use <kbd>Control</kbd> + <kbd>Command</kbd> + <kbd>F</kbd> on macOS to toggle full-screen mode
+- Full-screen mode toggling:
+  - Use <kbd>F11</kbd> on Windows
+  - Use <kbd>Control</kbd> + <kbd>Command</kbd> + <kbd>F</kbd> on macOS
+  - Click on the page
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ https://alphakevin.github.io/screen-color-tester/
 
 - Use <kbd>↑</kbd> or <kbd>←</kbd> to change color forward
 - Use <kbd>↓</kbd> or <kbd>→</kbd> to change color backward
-- Use <kbd>F11</kbd> to toggle full-screen mode
+- Use <kbd>F11</kbd> or click on the page to toggle full-screen mode
+- Use <kbd>Control</kbd> + <kbd>Command</kbd> + <kbd>F</kbd> on macOS to toggle full-screen mode
 
 ## References
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
         "white",
       ];
       let colorIndex = 0;
+
+      const toggleFullScreen = () => {
+        if (!document.fullscreenElement) {
+          document.documentElement.requestFullscreen();
+        } else if (document.exitFullscreen) {
+          document.exitFullscreen();
+        }
+      }
+
       window.addEventListener("keydown", (event) => {
         console.log(event.key);
         if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
@@ -29,6 +38,10 @@
           colorIndex = (colorIndex - 1 + colors.length) % colors.length;
         }
         document.body.style.backgroundColor = colors[colorIndex];
+      });
+
+      window.addEventListener("click", () => {
+        toggleFullScreen();
       });
     </script>
   </body>


### PR DESCRIPTION
Add full-screen mode toggle on page click and update README.md.

* **index.html**
  - Add `toggleFullScreen` function to handle full-screen mode toggling using arrow functions.
  - Add event listener for `click` event on the `window` object to toggle full-screen mode.
  - Remove `keydown` event listener for toggling full-screen mode.

* **README.md**
  - Update usage section to mention clicking on the page to toggle full-screen mode.
  - Merge the change for toggling full-screen mode with the keyboard shortcut.
  - Use `<kbd>` to wrap each key name in the usage section.
  - Add default keyboard shortcut for macOS to toggle full-screen mode.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alphakevin/screen-color-tester/pull/1?shareId=1cba4e95-4bbc-4859-8b33-9735246ca70e).