### PR TITLE
Add splash screen with help tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ https://alphakevin.github.io/screen-color-tester/
   - Use <kbd>Control</kbd> + <kbd>Command</kbd> + <kbd>F</kbd> on macOS
   - Click on the page
 
+## Splash Screen and Help Tips
+
+- A splash screen with help tips is shown when the app loads
+- The splash screen disappears after 5 seconds or when the user clicks the close button
+- The splash screen can be shown again by pressing the <kbd>H</kbd> key
+
 ## References
 
 - Online testing tool https://lcdtech.info/en/tests/dead.pixel.htm

--- a/index.html
+++ b/index.html
@@ -10,8 +10,45 @@
       padding: 0;
       cursor: none;
     }
+    .splash-screen {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.8);
+      color: white;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+      z-index: 1000;
+    }
+    .close-button {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      background-color: red;
+      color: white;
+      border: none;
+      padding: 10px;
+      cursor: pointer;
+    }
   </style>
   <body>
+    <dialog class="splash-screen" id="splash-screen" role="dialog" aria-labelledby="splash-title" aria-describedby="splash-description">
+      <h1 id="splash-title">Welcome to Screen Color Tester</h1>
+      <p id="splash-description">Use the following keys to navigate:</p>
+      <ul>
+        <li><kbd>↑</kbd> or <kbd>←</kbd> to change color forward</li>
+        <li><kbd>↓</kbd> or <kbd>→</kbd> to change color backward</li>
+        <li><kbd>F11</kbd> on Windows to toggle full-screen mode</li>
+        <li><kbd>Control</kbd> + <kbd>Command</kbd> + <kbd>F</kbd> on macOS to toggle full-screen mode</li>
+        <li>Click on the page to toggle full-screen mode</li>
+        <li>Press <kbd>H</kbd> to show this help screen</li>
+      </ul>
+      <button class="close-button" id="close-button">Close</button>
+    </dialog>
     <script>
       const colors = [
         "red",
@@ -30,12 +67,24 @@
         }
       }
 
+      const hideSplashScreen = () => {
+        document.getElementById('splash-screen').close();
+      }
+
+      const showSplashScreen = () => {
+        document.getElementById('splash-screen').showModal();
+      }
+
+      document.getElementById('close-button').addEventListener('click', hideSplashScreen);
+
       window.addEventListener("keydown", (event) => {
         console.log(event.key);
         if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
           colorIndex = (colorIndex + 1) % colors.length;
         } else if (event.key === "ArrowDown" || event.key === "ArrowRight") {
           colorIndex = (colorIndex - 1 + colors.length) % colors.length;
+        } else if (event.key === "H") {
+          showSplashScreen();
         }
         document.body.style.backgroundColor = colors[colorIndex];
       });
@@ -43,6 +92,8 @@
       window.addEventListener("click", () => {
         toggleFullScreen();
       });
+
+      setTimeout(hideSplashScreen, 5000);
     </script>
   </body>
 </html>


### PR DESCRIPTION
Add a splash screen with help tips when the app loads.

* **index.html**
  - Add a `<dialog>` element with help tips and a close button.
  - Add CSS styles for the splash screen and close button.
  - Add JavaScript to hide the splash screen after 5 seconds or when the close button is clicked.
  - Add JavaScript to show the splash screen when the `H` key is pressed.
  - Add accessibility attributes to the splash screen.

* **README.md**
  - Add a section about the splash screen and help tips.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alphakevin/screen-color-tester/pull/2?shareId=c083827e-0815-47ba-ae5d-a15319f896a1).